### PR TITLE
feat(docs): allow control tags

### DIFF
--- a/docs/endpoint.go
+++ b/docs/endpoint.go
@@ -15,6 +15,9 @@ import (
 type Endpoint openapi3.Operation
 
 func (e *Endpoint) SetTagsFromPath(path string) {
+	if e.Tags != nil {
+		return
+	}
 	pathNormalWords := strings.Split(path, "/")
 	for _, word := range pathNormalWords {
 		if !strings.Contains(word, ":") && word != "" {


### PR DESCRIPTION
Default tags generation are exhaustively. I am add ability to set Tags for endpoint, and other tags don't auto-generated for this endpoint. 
Also, if set Tags to empty strings slice, OpenAPI interpret this as `default` tag.
But if Tags as `nil` (by default) automatic generation work as previously. 